### PR TITLE
CI: add 3.8 + remove sudo

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 
 env:
   global:
@@ -9,14 +10,11 @@ matrix:
     - python: 2.7
     - python: 3.5
     - python: 3.6
-# Modification needed (https://github.com/travis-ci/travis-ci/issues/9815)
     - python: 3.7
-      dist: xenial
-      sudo: true
+    - python: 3.8
 
 
 install:
-  - sudo apt-get update
   - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"


### PR DESCRIPTION
* Hoping Python 3.8 will work
* Removed old `sudo` requirement for faster builds